### PR TITLE
Remove ' ' to fix compilation issues on latest Python package

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 FineTest - Desktop Application
 
 # Package
-pyinstaller -w --icon='ft-icon.icns' FineTest.py
+pyinstaller -w --icon=ft-icon.icns FineTest.py


### PR DESCRIPTION
Having ' ' in the pyinstaller command resulting in a compilation error in Windows.

C:\Users\Tuan Anh\Downloads\Compressed\FineTest-main_2\FineTest-main>pyinstaller -w --icon='ft-icon.icns' FineTest.py 218 INFO: PyInstaller: 5.7.0
219 INFO: Python: 3.11.1
227 INFO: Platform: Windows-10-10.0.22621-SP0
227 INFO: wrote C:\Users\Tuan Anh\Downloads\Compressed\FineTest-main_2\FineTest-main\FineTest.spec 229 INFO: UPX is not available.
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Users\Tuan Anh\AppData\Local\Programs\Python\Python311\Scripts\pyinstaller.exe\__main__.py", line 7, in <module>
  File "C:\Users\Tuan Anh\AppData\Local\Programs\Python\Python311\Lib\site-packages\PyInstaller\__main__.py", line 194, in _console_script_run
    run()
  File "C:\Users\Tuan Anh\AppData\Local\Programs\Python\Python311\Lib\site-packages\PyInstaller\__main__.py", line 180, in run
    run_build(pyi_config, spec_file, **vars(args))
  File "C:\Users\Tuan Anh\AppData\Local\Programs\Python\Python311\Lib\site-packages\PyInstaller\__main__.py", line 61, in run_build
    PyInstaller.building.build_main.main(pyi_config, spec_file, **kwargs)
  File "C:\Users\Tuan Anh\AppData\Local\Programs\Python\Python311\Lib\site-packages\PyInstaller\building\build_main.py", line 971, in main
    build(specfile, distpath, workpath, clean_build)
  File "C:\Users\Tuan Anh\AppData\Local\Programs\Python\Python311\Lib\site-packages\PyInstaller\building\build_main.py", line 890, in build
    code = compile(f.read(), spec, 'exec')
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Tuan Anh\Downloads\Compressed\FineTest-main_2\FineTest-main\FineTest.spec", line 40
    icon=[''ft-icon.icns''],
          ^^^^^^^^^^^^^^
SyntaxError: invalid syntax. Perhaps you forgot a comma?

While you can compile without ' ' still fine.